### PR TITLE
fix: Resolves Database Does Not Exist Error Snowflake

### DIFF
--- a/models/queries.sql
+++ b/models/queries.sql
@@ -2,7 +2,7 @@ WITH columns AS (
     SELECT
         column_name AS cn,
         table_catalog || '.' || table_schema || '.' || table_name AS tn
-    FROM "{{ var('source-database', target.database) }}".{{ source('information_schema', 'columns').include(database=false) }}
+    FROM {{ var('source-database', target.database) }}.{{ source('information_schema', 'columns').include(database=false) }}
     WHERE
         LOWER(column_name) IN {{ var('id-columns') }}
         {% if var('schemas-to-include', undefined) %}


### PR DESCRIPTION
## Description of the change

Removes the `"` double quotes around the database object in `queries.sql`. In Snowflake the object is case sensitive when surrounded by double quotes. This resolves that issue. Not tested on other SQL engines.

```
❯ dbt run -s queries edges
13:26:11  Running with dbt=1.6.2
13:26:11  Registered adapter: snowflake=1.6.2
...
13:26:30  1 of 2 START sql view model beta.queries ....................................... [RUN]
13:26:32  1 of 2 ERROR creating sql view model beta.queries .............................. [ERROR in 1.88s]
13:26:32  2 of 2 SKIP relation beta.edges ................................................ [SKIP]
13:26:32  
13:26:32  Running 1 on-run-end hook
13:26:32  1 of 1 START hook: source_products.on-run-end.0 ................................ [RUN]
13:26:32  1 of 1 OK hook: source_products.on-run-end.0 ................................... [OK in 0.00s]
13:26:32  
13:26:32  
13:26:32  Finished running 1 view model, 1 incremental model, 2 hooks in 0 hours 0 minutes and 14.85 seconds (14.85s).
13:26:32  
13:26:32  Completed with 1 error and 0 warnings:
13:26:32  
13:26:32    Database Error in model queries (models/queries.sql)
  002003 (02000): SQL compilation error:
  Database '"dev_bart"' does not exist or not authorized.
  compiled Code at target/run/id_stitching/models/queries.sql
13:26:32  
13:26:32  Done. PASS=0 WARN=0 ERROR=1 SKIP=1 TOTAL=2
```

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
